### PR TITLE
Potential fix for code scanning alert no. 2: Clear text transmission of sensitive cookie

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -14,6 +14,12 @@ app.use(express.json())
 app.use(express.urlencoded({extended: false}))
 app.use(layouts)
 
+// Ensure cookies are only sent over HTTPS in production
+const isProduction = process.env.NODE_ENV === 'production';
+if (isProduction && process.env.USE_HTTP) {
+  console.error('ERROR: Application is running in production mode without HTTPS. Session cookies will not be secure!');
+  throw new Error('Refusing to start server in production mode without HTTPS. Set up HTTPS and remove USE_HTTP.');
+}
 app.use(session({
   name: process.env.COOKIE_NAME || 'ttcloud-cookie-session',
   secret: process.env.COOKIE_SECRET,
@@ -21,7 +27,9 @@ app.use(session({
   saveUninitialized: false,
   cookie:{
     maxAge: 24 * 60 * 60 * 1000,
-    secure: process.env.NODE_ENV === 'production' || false,
+    secure: isProduction, // Always secure in production
+    httpOnly: true,
+    sameSite: 'lax',
     domain: process.env.COOKIE_DOMAIN || 'localhost'
   }
 }))


### PR DESCRIPTION
Potential fix for [https://github.com/TTNRT/ttcloud/security/code-scanning/2](https://github.com/TTNRT/ttcloud/security/code-scanning/2)

To fix the problem, ensure that the session cookie is always marked as `secure` in production, and that the application fails to start (or at least logs a strong warning) if it is running in production without HTTPS. Additionally, you can add the `sameSite: 'strict'` or `'lax'` attribute to further protect the cookie. The best fix is to:

- Explicitly check if the app is running in production and if so, require that the `secure` flag is set and that HTTPS is being used.
- Optionally, log a warning or throw an error if the app is in production but not using HTTPS.
- For development, you may leave `secure: false`, but document this in a comment.

You only need to edit the session middleware configuration in `index.cjs` (lines 17–27). No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
